### PR TITLE
Added optional HTML sanitization of readable contents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,33 @@ Note about CORS: by design, the server will allow any origin to access it, so br
 Usage
 -----
 
+### `GET /get`
+
+#### Required parameters
+
+- `url`: The URL to retrieve retrieve readable contents from, eg. `https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/`.
+
+#### Optional parameters
+
+- `sanitize`: A *boolean string* to enable HTML sanitization (valid truthy boolean strings: "1", "on", "true", "yes", "y"; everything else will be considered falsy):
+
+**Note:** Enabling contents sanitization loses Readability.js specific HTML semantics, though is probably safer for users if you plan to publish retrieved contents on a public website.
+
+#### Example
+
+Content sanitization enabled:
+
+    $ curl http://0.0.0.0:3000/get\?sanitize=y&url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
+    {
+      "byline":"Nicolas Perriault —",
+      "content":"<p><strong>So finally you&#39;re <a href=\"https://nicolas.perriault.net/code/2013/testing-frontend-javascript-code-using-mocha-chai-and-sinon/\">testing",
+      "length":2867,
+      "title":"Get your Frontend JavaScript Code Covered | Code",
+      "uri":"https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/"
+    }
+
+Content sanitization disabled (default):
+
     $ curl http://0.0.0.0:3000/get\?url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
     {
       "byline":"Nicolas Perriault —",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "bluebird": "^2.9.12",
     "express": "^4.11.2",
+    "html-md": "^3.0.2",
+    "markdown": "^0.5.0",
     "phantomjs": "^1.9.15"
   }
 }


### PR DESCRIPTION
## Usage
### `GET /get`
#### Required parameters
- `url`: The URL to retrieve retrieve readable contents from, eg. `https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/`.
#### Optional parameters
- `sanitize`: A _boolean string_ to enable HTML sanitization (valid truthy boolean strings: "1", "on", "true", "yes", "y"; everything else will be considered falsy):

**Note:** Enabling contents sanitization loses Readability.js specific HTML semantics, though is probably safer for users if you plan to publish retrieved contents on a public website.
#### Example

Content sanitization enabled:

```
$ curl http://0.0.0.0:3000/get\?sanitize=y&url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
{
  "byline":"Nicolas Perriault —",
  "content":"<p><strong>So finally you&#39;re <a href=\"https://nicolas.perriault.net/code/2013/testing-frontend-javascript-code-using-mocha-chai-and-sinon/\">testing",
  "length":3851,
  "title":"Get your Frontend JavaScript Code Covered | Code",
  "uri":"https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/"
}
```

Content sanitization disabled (default):

```
$ curl http://0.0.0.0:3000/get\?url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
{
  "byline":"Nicolas Perriault —",
  "content":"<div id=\"readability-page-1\" class=\"page\"><section class=\"\">\n<p><strong>So finally you're…",
  "length":3851,
  "title":"Get your Frontend JavaScript Code Covered | Code",
  "uri":"https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/"
}
```
