### PR TITLE
Added comparison view, configurable Readability.js path used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,45 @@ Starts server on `localhost:3000`:
 
 Note about CORS: by design, the server will allow any origin to access it, so browsers can consume it from pages hosted on a different domain.
 
+Configuration
+-------------
+
+By default, the proxy server will use the Readability.js version it ships with; to override this, you can set the `READABILITY_LIB_PATH` environment variable to the absolute path to the library file on your local system:
+
+    $ READABILITY_LIB_PATH=/path/to/my/own/version/of/Readability.js npm start
+
 Usage
 -----
 
-### `GET /get`
+### Web UI
 
-#### Required parameters
+Just head to `http://localhost:3000/`, enter some URL and start enjoying both original and readable renderings side by side.
+
+![](https://s3.amazonaws.com/f.cl.ly/items/1L0E3W2U3N0Y25111y2i/Screen%20Shot%202015-02-24%20at%2013.31.10.png)
+
+### REST/JSON API
+
+The HTTP Rest API is available under `/api`.
+
+**Disclaimer:** Truly *REST* implementation is probably far from being considered achieved.
+
+#### `GET /api/get`
+
+##### Required parameters
 
 - `url`: The URL to retrieve retrieve readable contents from, eg. `https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/`.
 
-#### Optional parameters
+##### Optional parameters
 
 - `sanitize`: A *boolean string* to enable HTML sanitization (valid truthy boolean strings: "1", "on", "true", "yes", "y"; everything else will be considered falsy):
 
 **Note:** Enabling contents sanitization loses Readability.js specific HTML semantics, though is probably safer for users if you plan to publish retrieved contents on a public website.
 
-#### Example
+##### Example
 
 Content sanitization enabled:
 
-    $ curl http://0.0.0.0:3000/get\?sanitize=y&url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
+    $ curl http://0.0.0.0:3000/api/get\?sanitize=y&url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
     {
       "byline":"Nicolas Perriault —",
       "content":"<p><strong>So finally you&#39;re <a href=\"https://nicolas.perriault.net/code/2013/testing-frontend-javascript-code-using-mocha-chai-and-sinon/\">testing",
@@ -50,7 +69,7 @@ Content sanitization enabled:
 
 Content sanitization disabled (default):
 
-    $ curl http://0.0.0.0:3000/get\?url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
+    $ curl http://0.0.0.0:3000/api/get\?url\=https://nicolas.perriault.net/code/2013/get-your-frontend-javascript-code-covered/
     {
       "byline":"Nicolas Perriault —",
       "content":"<div id=\"readability-page-1\" class=\"page\"><section class=\"\">\n<p><strong>So finally you're…",

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var html2md = require("html-md");
 var markdown = require("markdown");
 
 var app = express();
+app.use(express.static('static'));
 
 /**
  * Casts a qs string arg into an actual boolean.
@@ -40,7 +41,7 @@ app.use(function(req, res, next) {
   next();
 });
 
-app.get("/", function(req, res) {
+app.get("/api", function(req, res) {
   res.json({
     name: pkgInfo.name,
     documentation: "https://github.com/n1k0/readable-proxy/blob/master/README.md",
@@ -49,7 +50,7 @@ app.get("/", function(req, res) {
   });
 });
 
-app.get("/get", function(req, res) {
+app.get("/api/get", function(req, res) {
   var url = req.query.url, sanitize = boolArg(req.query.sanitize);
   if (!url) {
     return res.status(400).json({error: "Missing url parameter"});

--- a/scrape.js
+++ b/scrape.js
@@ -4,9 +4,12 @@ var binPath = phantomjs.path;
 var path = require("path");
 var Promise = require("bluebird");
 
+var readabilityPath = process.env.READABILITY_LIB_PATH ||
+                      path.normalize(path.join(__dirname, "vendor", "Readability.js"));
+
 module.exports = function scrape(url) {
   return new Promise(function(fulfill, reject) {
-    var childArgs = [path.join(__dirname, "phantom-scrape.js"), url];
+    var childArgs = [path.join(__dirname, "phantom-scrape.js"), url, readabilityPath];
     childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
       if (err) {
         return reject(err);

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Readability.js test page</title>
+  <style>
+  body {
+    background-color: #ffe;
+    font-size: 18px;
+  }
+  form { margin: 1em 0; }
+  input { font-size: 16px; }
+  iframe {
+    width: 49%;
+    height: 640px;
+    background: #fff;
+  }
+  iframe body {
+    font-size: 22px;
+  }
+  </style>
+</head>
+<body>
+  <h1>Readability.js test page</h1>
+  <form id="form">
+    <p><label>URL
+      <input type="url" id="url" size="120" placeholder="http://">
+    </label></p>
+    <p><label>
+      <input type="checkbox" id="sanitize"> Sanitize output
+    </label></p>
+    <input type="submit">
+  </form>
+  <iframe id="source"></iframe>
+  <iframe id="target"></iframe>
+  <script>
+    var q = document.querySelector.bind(document);
+
+    function injectReadableContents(url, sanitize, target) {
+      var req = new XMLHttpRequest();
+      req.open("GET", "/api/get?sanitize=" + (sanitize ? "yes" : "no") + "&url=" + encodeURIComponent(url), false);
+      req.send(null);
+      target.contentDocument.body.innerHTML = JSON.parse(req.responseText).content;
+    }
+
+    q("form").addEventListener("submit", function(event) {
+      event.preventDefault();
+      var url = q("#url").value;
+      q("#source").src = url;
+      injectReadableContents(url, q("#sanitize").checked, q("#target"));
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
As we're [planning](https://github.com/mozilla/readability/issues/11#issuecomment-75661788) to use this proxy to help manually developing & testing the Readability.js library, this adds a new Web UI allowing to easily submit and render readable contents from a given URL:

![screen shot 2015-02-24 at 13 31 10](https://cloud.githubusercontent.com/assets/41547/6349390/289b0ad8-bc2a-11e4-9aa3-3d450fdcfd89.png)

Also, this patch allows defining a custom Readability.js file path, using the `READABILITY_LIB_PATH` env var — so it's easier to setup & use on lib developer computers.

That means running:

```
$ READABILITY_LIB_PATH=/path/to/Readability.js npm start 
```

will make the proxy using that local version of Readability.
