### PR TITLE
Show output of isProbablyReaderable()

### DIFF
--- a/phantom-scrape.js
+++ b/phantom-scrape.js
@@ -31,9 +31,12 @@ function runReadability(url, userAgent, pageContent) {
     pathBase: location.protocol + "//" + location.host + location.pathname.substr(0, location.pathname.lastIndexOf("/") + 1)
   };
   try {
-    var result = new Readability(uri, document).parse();
+    var readabilityObj = new Readability(uri, document);
+    var isProbablyReaderable = readabilityObj.isProbablyReaderable();
+    var result = readabilityObj.parse();
     if (result) {
       result.userAgent = userAgent;
+      result.isProbablyReaderable = isProbablyReaderable;
     } else {
       result = {
         error: {

--- a/static/index.html
+++ b/static/index.html
@@ -50,6 +50,7 @@
       </div>
       <div class="col-md-6">
         <table class="table table-striped">
+          <tr><th>Readerable?</th><td id="readerable"></td></tr>
           <tr><th>Title</th><td id="title"></td></tr>
           <tr><th>Dir</th><td id="dir"></td></tr>
           <tr><th>Byline</th><td id="byline"></td></tr>

--- a/static/main.js
+++ b/static/main.js
@@ -17,6 +17,7 @@
     if (jsonResponse.error) {
       q("#error").textContent = jsonResponse.error.message;
       q("#error").classList.remove("hide");
+      q("#readerable").textContent = "";
       q("#title").textContent = "";
       q("#byline").textContent = "";
       q("#length").textContent = "";
@@ -26,6 +27,7 @@
       target.contentDocument.body.innerHTML = "";
     } else {
       q("#error").textContent = "";
+      q("#readerable").textContent = jsonResponse.isProbablyReaderable;
       q("#title").textContent = jsonResponse.title;
       q("#byline").textContent = jsonResponse.byline;
       q("#length").textContent = jsonResponse.length;


### PR DESCRIPTION
Some pages parse correctly, but don't pass the isProbablyReaderable test, which Firefox uses before attempting to parse.
Therefore, it is important to know its output!

This patch calls isProbablyReadable() and displays the result in the summary table.
