### PR TITLE
Update PhantomJS to 2.1.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "html-md": "^3.0.*",
     "markdown": "^0.5.*",
     "object-assign": "^2.0.*",
-    "phantomjs": "^1.9.*"
+    "phantomjs-prebuilt": "^2.1.*"
   },
   "devDependencies": {
     "chai": "^2.1.*",

--- a/scrape.js
+++ b/scrape.js
@@ -1,5 +1,5 @@
 var childProcess = require("child_process");
-var phantomjs = require("phantomjs");
+var phantomjs = require("phantomjs-prebuilt");
 var binPath = phantomjs.path;
 var path = require("path");
 var Promise = require("bluebird");


### PR DESCRIPTION
The motivation for this change is better HTTPS handling in the 2.1 version compared to 1.9 (#18).

The `npm test` tests still pass for me with the new version, and the release notes for [2.0](http://phantomjs.org/release-2.0.html) and [2.1](http://phantomjs.org/release-2.1.html) don't appear to have anything problematic (except for "OS X 10.6 (Snow Leopard) is not supported anymore" in 2.0 release notes, but it appears to be fixed in 2.1).
